### PR TITLE
Enable optional chown use instead of setfacl

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -77,6 +77,7 @@ The following environment variables are also honored for configuring your ElkarB
 |----------|---------------|---------------|
 | TZ       | Europe/Paris  | Timezone      |
 | PHP_TZ   | Europe/Paris  | Timezone (PHP)|
+| EB_ACL   | enabled       | use setfacl, otherwise use chown|
 | EB_CRON  | enabled       | run tick command periodically|
 
 ### Database configuration


### PR DESCRIPTION
As part of the docker entrypoint.sh, various directory permissions get modified to enable the apache user to write to them.

When runnnig on a regula host, the fs layer handles these setfacl calls. But when running on common NAS systems, these calls fail.

Added: Environment parameter `EB_ACL` to enable/disable use of setfacl
       and instead fall back to chown.
Added: Autodetection of synology and qnap devices and automatically
       set `EB_ACL=disabled`.
Fixes: https://github.com/elkarbackup/elkarbackup/issues/581 Closes: https://github.com/elkarbackup/elkarbackup/issues/618