### PR TITLE
Support diskus in addition to the existing du command for diskspace calculation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,7 +78,9 @@ RUN apt-get update && apt-get install -y \
       pcntl
 
 # Download and install diskus
-RUN curl -sL https://github.com/sharkdp/diskus/releases/download/v0.8.0/diskus_0.8.0_amd64.deb | dpkg -i -
+RUN curl -sL -o diskus.deb https://github.com/sharkdp/diskus/releases/download/v0.8.0/diskus_0.8.0_amd64.deb && \
+  dpkg -i diskus.deb && \
+  rm -f diskus.deb
 
 # Download and install composer
 COPY --from=composer:2.1 /usr/bin/composer /usr/bin/composer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,6 +77,9 @@ RUN apt-get update && apt-get install -y \
       pdo_mysql \
       pcntl
 
+# Download and install diskus
+curl -sL https://github.com/sharkdp/diskus/releases/download/v0.8.0/diskus_0.8.0_amd64.deb | dpkg -i -
+
 # Download and install composer
 COPY --from=composer:2.1 /usr/bin/composer /usr/bin/composer
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get update && apt-get install -y \
       pcntl
 
 # Download and install diskus
-curl -sL https://github.com/sharkdp/diskus/releases/download/v0.8.0/diskus_0.8.0_amd64.deb | dpkg -i -
+RUN curl -sL https://github.com/sharkdp/diskus/releases/download/v0.8.0/diskus_0.8.0_amd64.deb | dpkg -i -
 
 # Download and install composer
 COPY --from=composer:2.1 /usr/bin/composer /usr/bin/composer

--- a/src/Command/RunJobCommand.php
+++ b/src/Command/RunJobCommand.php
@@ -273,7 +273,7 @@ class RunJobCommand extends LoggingCommand
         
         /* setDiskUsage()*/
         $this->info('Client "%clientid%", Job "%jobid%" du begin.', array('%clientid%' => $job->getClient()->getId(), '%jobid%' => $job->getId()), $context);
-        $du = (int)shell_exec(sprintf("du -ks '%s' | sed 's/\t.*//'", $job->getSnapshotRoot()));
+        $du = (int)shell_exec(sprintf("diskus '%s' | awk -F '[() ]' '{gsub(\",\", \"\", $4); print $4 / 1024}'", $job->getSnapshotRoot()));
         $job->setDiskUsage($du);
         $this->info('Client "%clientid%", Job "%jobid%" du end.', array('%clientid%' => $job->getClient()->getId(), '%jobid%' => $job->getId()), $context);
         

--- a/src/Command/RunJobCommand.php
+++ b/src/Command/RunJobCommand.php
@@ -273,7 +273,12 @@ class RunJobCommand extends LoggingCommand
         
         /* setDiskUsage()*/
         $this->info('Client "%clientid%", Job "%jobid%" du begin.', array('%clientid%' => $job->getClient()->getId(), '%jobid%' => $job->getId()), $context);
-        $du = (int)shell_exec(sprintf("diskus '%s' | awk -F '[() ]' '{print $0 / 1024}'", $job->getSnapshotRoot()));
+        // if diskus is installed, use that as it is faster by orders of magnitude
+        if (trim(shell_exec('command -v diskus'))) {
+            $du = (int)shell_exec(sprintf("diskus '%s' | awk -F '[() ]' '{print $0 / 1024}'", $job->getSnapshotRoot()));
+        } else {
+            $du = (int)shell_exec(sprintf("du -ks '%s' | sed 's/\t.*//'", $job->getSnapshotRoot()));
+        }
         $job->setDiskUsage($du);
         $this->info('Client "%clientid%", Job "%jobid%" du end.', array('%clientid%' => $job->getClient()->getId(), '%jobid%' => $job->getId()), $context);
         

--- a/src/Command/RunJobCommand.php
+++ b/src/Command/RunJobCommand.php
@@ -273,7 +273,7 @@ class RunJobCommand extends LoggingCommand
         
         /* setDiskUsage()*/
         $this->info('Client "%clientid%", Job "%jobid%" du begin.', array('%clientid%' => $job->getClient()->getId(), '%jobid%' => $job->getId()), $context);
-        $du = (int)shell_exec(sprintf("diskus '%s' | awk -F '[() ]' '{gsub(\",\", \"\", $4); print $4 / 1024}'", $job->getSnapshotRoot()));
+        $du = (int)shell_exec(sprintf("diskus '%s' | awk -F '[() ]' '{print $0 / 1024}'", $job->getSnapshotRoot()));
         $job->setDiskUsage($du);
         $this->info('Client "%clientid%", Job "%jobid%" du end.', array('%clientid%' => $job->getClient()->getId(), '%jobid%' => $job->getId()), $context);
         


### PR DESCRIPTION
`du` takes a long time to complete. For some jobs here the backup is 30min and the du-job is 2hrs.
The time spent on this mainly informational message is in no relation to its usefulness and also
delays other jobs.

Instead use diskus from https://github.com/sharkdp/diskus which is a faster alternative.

Related upstream bug report: https://github.com/elkarbackup/elkarbackup/issues/353