### PR TITLE
Improve diskspace usage

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Run test suite
-        run: docker-compose -f docker/test/docker-compose.yml up --abort-on-container-exit --exit-code-from elkarbackup
+        run: docker compose -f docker/test/docker-compose.yml up --abort-on-container-exit --exit-code-from elkarbackup

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 ## Bootstrap & Build elkarbackup
 ##
 
-FROM php:7.3-cli-alpine
+FROM php:7.4-cli-alpine
 
 RUN apk add --no-cache \
       git \
@@ -56,7 +56,7 @@ COPY $DOCKERDIR/src/Builder.php /app/elkarbackup/src/Menu/Builder.php
 ## Composer install
 RUN set -ex; \
       cd /app/elkarbackup; \
-      composer install --no-interaction
+      composer update --no-interaction --no-audit
 
 
 ##
@@ -64,18 +64,34 @@ RUN set -ex; \
 ##
 
 
-FROM php:7.3-apache-buster
+FROM php:7.4-apache-bullseye
 RUN apt-get update && apt-get install -y \
       default-mysql-client \
       acl \
-      rsnapshot \
       sudo \
       git \
       zip \
+      rsync \
+      perl \
+      libconfig-inifiles-perl \
+      liblchown-perl \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-install \
       pdo_mysql \
       pcntl
+
+# Install rsnapshot from source (not available in bullseye repos)
+RUN apt-get update && apt-get install -y autoconf automake \
+    && cd /tmp \
+    && git clone https://github.com/rsnapshot/rsnapshot.git \
+    && cd rsnapshot \
+    && ./autogen.sh \
+    && ./configure --sysconfdir=/etc \
+    && make install \
+    && rm -rf /tmp/rsnapshot \
+    && apt-get purge -y autoconf automake \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Download and install composer
 COPY --from=composer:2.1 /usr/bin/composer /usr/bin/composer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,6 +80,12 @@ RUN apt-get update && apt-get install -y \
       pdo_mysql \
       pcntl
 
+# Download and install diskus
+RUN curl -sL -o diskus.deb \
+    https://github.com/sharkdp/diskus/releases/download/v0.8.0/diskus_0.8.0_$(dpkg --print-architecture).deb && \
+    dpkg -i diskus.deb && \
+    rm -f diskus.deb
+
 # Install rsnapshot from source (not available in bullseye repos)
 RUN apt-get update && apt-get install -y autoconf automake \
     && cd /tmp \

--- a/docker/composer.json.docker
+++ b/docker/composer.json.docker
@@ -5,13 +5,17 @@
 		"php" : ">=7.1.3",
 		"ext-ctype" : "*",
 		"ext-iconv" : "*",
+		"api-platform/core" : "^2.6",
+		"composer/package-versions-deprecated" : "1.11.99.1",
 		"doctrine/annotations" : "^1.12",
 		"doctrine/doctrine-bundle" : "^2.2",
 		"doctrine/doctrine-migrations-bundle" : "^3.0",
-		"doctrine/orm" : "^2.8",
+		"doctrine/orm" : "^2.8,<2.15",
 		"incenteev/composer-parameter-handler" : "^2.1",
 		"knplabs/knp-menu-bundle" : "^3.1",
 		"knplabs/knp-paginator-bundle" : "^5.4",
+		"nelmio/cors-bundle" : "^2.1",
+		"phpdocumentor/reflection-docblock" : "^5.2",
 		"sensio/framework-extra-bundle" : "^6.1",
 		"symfony/asset" : "4.4.*",
 		"symfony/console" : "4.4.*",
@@ -22,8 +26,13 @@
 		"symfony/framework-bundle" : "4.4.*",
 		"symfony/lock" : "4.4.*",
 		"symfony/monolog-bundle" : "^3.6",
+		"symfony/process" : "4.4.*",
+		"symfony/property-access" : "4.4.*",
+		"symfony/property-info" : "4.4.*",
+		"symfony/proxy-manager-bridge" : "4.4.*",
 		"symfony/security-bundle" : "4.4.*",
 		"symfony/security-csrf" : "4.4.*",
+		"symfony/serializer" : "4.4.*",
 		"symfony/swiftmailer-bundle" : "^3.5",
 		"symfony/templating" : "4.4.*",
 		"symfony/twig-bundle" : "4.4.*",
@@ -31,7 +40,6 @@
 		"symfony/web-profiler-bundle" : "4.4.*",
 		"symfony/yaml" : "4.4.*",
 		"twbs/bootstrap" : "^3.3",
-		"twig/extensions" : "^1.5",
 		"twig/extra-bundle" : "^2.12|^3.0",
 		"twig/twig" : "^2.12"
 	},
@@ -53,7 +61,15 @@
 		"preferred-install" : {
 			"*" : "dist"
 		},
-		"sort-packages" : true
+		"sort-packages" : true,
+		"audit" : {
+			"abandoned" : "ignore",
+			"block-insecure" : false
+		},
+		"allow-plugins" : {
+			"symfony/flex" : true,
+			"incenteev/composer-parameter-handler" : true
+		}
 	},
 	"autoload" : {
 		"psr-4" : {
@@ -76,6 +92,14 @@
 	"conflict" : {
 		"symfony/symfony" : "*"
 	},
+	"require-dev" : {
+		"hautelook/alice-bundle" : "^2.9",
+		"justinrainbow/json-schema" : "^5.2",
+		"symfony/browser-kit" : "^4.4",
+		"symfony/css-selector" : "^4.4",
+		"symfony/http-client" : "4.4.*",
+		"symfony/phpunit-bridge" : "^5.2"
+	},
 	"extra" : {
 		"symfony" : {
 			"allow-contrib" : false,
@@ -84,11 +108,5 @@
 		"incenteev-parameters" : {
 			"file" : "config/parameters.yaml"
 		}
-	},
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/theofidry/AliceBundle"
-		}
-	]
+	}
 }

--- a/docker/test/run-elkarbackup-tests.sh
+++ b/docker/test/run-elkarbackup-tests.sh
@@ -1,1 +1,1 @@
-docker-compose up --exit-code-from elkarbackup
+docker compose up --exit-code-from elkarbackup

--- a/src/Command/RunJobCommand.php
+++ b/src/Command/RunJobCommand.php
@@ -273,7 +273,12 @@ class RunJobCommand extends LoggingCommand
         
         /* setDiskUsage()*/
         $this->info('Client "%clientid%", Job "%jobid%" du begin.', array('%clientid%' => $job->getClient()->getId(), '%jobid%' => $job->getId()), $context);
-        $du = (int)shell_exec(sprintf("du -ks '%s' | sed 's/\t.*//'", $job->getSnapshotRoot()));
+        // if diskus is installed, use that as it is so much faster than plain du
+        if (trim(shell_exec('command -v diskus'))) {
+            $du = (int)shell_exec(sprintf("diskus '%s' | awk -F '[() ]' '{print $0 / 1024}'", $job->getSnapshotRoot()));
+        } else {
+            $du = (int)shell_exec(sprintf("du -ks '%s' | sed 's/\t.*//'", $job->getSnapshotRoot()));
+        }
         $job->setDiskUsage($du);
         $this->info('Client "%clientid%", Job "%jobid%" du end.', array('%clientid%' => $job->getClient()->getId(), '%jobid%' => $job->getId()), $context);
         


### PR DESCRIPTION
`du` takes a long time to complete. For some jobs here the backup is 30min and the du-job is 2hrs.
The time spent on this mainly informational message is in no relation to its usefulness and also
delays other jobs.

Instead use diskus from https://github.com/sharkdp/diskus which is a faster alternative.

Related upstream bug report: elkarbackup#353
